### PR TITLE
Suppress warnings

### DIFF
--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -1054,11 +1054,11 @@ describe List do
   it "sample" do
     100.times do
       s = [2,1,0].sample
-      expect(s).to be_a_kind_of(Fixnum)
+      expect(s).to be_a_kind_of(Integer)
       expect(s).to be >= 0
       expect(s).to be <= 2
       @cls[2,1,0].sample(2).each {|sample|
-        expect(sample).to be_a_kind_of(Fixnum)
+        expect(sample).to be_a_kind_of(Integer)
         expect(sample).to be >= 0
         expect(sample).to be <= 2
       }

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -87,7 +87,7 @@ describe List do
     list.freeze
     expect(list).to eq(@cls[])
     expect(list.frozen?).to eq(true)
-    expect{ list.push 1 }.to raise_error
+    expect{ list.push 1 }.to raise_error(FrozenError)
   end
 
   it "==" do


### PR DESCRIPTION
`rake spec`  raise some warnings, this PR suppresses the warnings (Ruby 2.6)

## Replace deprecated Fixnum with Integer

> list/spec/list_spec.rb:1057: warning: constant ::Fixnum is deprecated
list/spec/list_spec.rb:1061: warning: constant ::Fixnum is deprecated

## Specify FrozenError on a test

> WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<FrozenError: can't modify frozen List>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from list/spec/list_spec.rb:90:in `block (2 levels) in <top (required)>'.