### PR TITLE
Change output of List

### DIFF
--- a/ext/list/list.c
+++ b/ext/list/list.c
@@ -549,16 +549,16 @@ inspect_list(VALUE self, VALUE dummy, int recur)
 
 	if (recur) return rb_usascii_str_new_cstr("[...]");
 
-	str = rb_str_buf_new2("#<");
+	str = rb_str_buf_new2("");
 	rb_str_buf_cat2(str, rb_obj_classname(self));
-	rb_str_buf_cat2(str, ": [");
+	rb_str_buf_cat2(str, "[");
 	LIST_FOR(self, c) {
 		s = rb_inspect(c->value);
 		if (LIST_PTR(self)->first == c) rb_enc_copy(str, s);
 		else rb_str_buf_cat2(str, ", ");
 		rb_str_buf_append(str, s);
 	}
-	rb_str_buf_cat2(str, "]>");
+	rb_str_buf_cat2(str, "]");
 	return str;
 }
 
@@ -566,7 +566,7 @@ static VALUE
 list_inspect(VALUE self)
 {
 	if (LIST_LEN(self) == 0)
-		return rb_sprintf("#<%s: []>", rb_obj_classname(self));
+		return rb_sprintf("%s[]", rb_obj_classname(self));
 	return rb_exec_recursive(inspect_list, self, 0);
 }
 

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -68,10 +68,10 @@ describe List do
 
   it "inspect" do
     list = @cls.new
-    expect(list.inspect).to eq("#<#{@cls}: []>")
+    expect(list.inspect).to eq("#{@cls}[]")
     list.push 1,[2],{:a=>3}
-    expect(list.inspect).to eq("#<#{@cls}: [1, [2], {:a=>3}]>")
-    expect(@subcls[1,2,3].inspect).to eq("#<#{@subcls}: [1, 2, 3]>")
+    expect(list.inspect).to eq("#{@cls}[1, [2], {:a=>3}]")
+    expect(@subcls[1,2,3].inspect).to eq("#{@subcls}[1, 2, 3]")
   end
 
   it "to_a" do


### PR DESCRIPTION
before:
```
puts List[]      #=> #<List: []>
p List[1, 2, 3]  #=> #<List: [1, 2, 3]>
```

after:
```
puts List[]      #=> List[]
p List[1, 2, 3]  #=> List[1, 2, 3] 
```
